### PR TITLE
Remove unused shadcn-react import

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import App from './App.jsx'
 import CalendarPage from './pages/Calendar.jsx'
-import 'shadcn-react/style.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- revert previous dependency addition
- remove import of non-existent shadcn-react styles

## Testing
- `pnpm run test`
- `pnpm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6845b840acb48321837a8c5d7588a437