### PR TITLE
Adjust logo size and card spacing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,11 @@ export default function App() {
     <div id="app">
       <header>
         <Button variant="ghost" onClick={() => navigate('/')}>
-          <img src={brandImg} alt="Ayah Calendar" className="h-10" />
+          <img
+            src={brandImg}
+            alt="Ayah Calendar"
+            className="h-[100px] w-[100px]"
+          />
         </Button>
         <Button variant="link" onClick={() => navigate('/')}>Ayah Calendar</Button>
       </header>

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -47,11 +47,13 @@ export default function CalendarPage() {
   return (
     <div>
       <Calendar mode="single" selected={date} onSelect={setDate} />
-      <div>
+      <div className="space-y-4 mt-4">
         {(eventsByDate[date.toISOString().slice(0,10)] || []).map((ayah, idx) => (
-          <Card key={idx}>
+          <Card key={idx} className="p-4">
             <CardHeader>
-              <CardTitle>{ayah.title} <small>{ayah.num}</small></CardTitle>
+              <CardTitle>
+                {ayah.title} <small>{ayah.num}</small>
+              </CardTitle>
             </CardHeader>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- tweak header logo size to 100x100
- add padding inside ayah cards
- add spacing between ayah cards

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f8834f008321b4f82131701ded4c